### PR TITLE
Correct folder name in modpack setup instructions

### DIFF
--- a/MODPACK_GUIDE.md
+++ b/MODPACK_GUIDE.md
@@ -3,8 +3,8 @@
 Setup is straightforward:
 
 1. Add Config Manager to your modpack (from [Modrinth] or [CurseForge]).
-2. Copy all configuration files into a folder called `modpack_default` inside `config/`.
-3. The structure inside `modpack_default` should mirror the root of the Minecraft directory.
+2. Copy all configuration files into a folder called `modpack_defaults` inside `config/`.
+3. The structure inside `modpack_defaults` should mirror the root of the Minecraft directory.
 
 **Example:**
 ```

--- a/common/src/main/resources/assets/config_manager/lang/tt_ru.json
+++ b/common/src/main/resources/assets/config_manager/lang/tt_ru.json
@@ -1,0 +1,14 @@
+{
+  "modmenu.summaryTranslation.config_manager": "Мод җыелмасын ясаучыларга кулланучыга иң мөмкин дус рәвешендә бирә.",
+  "modmenu.descriptionTranslation.config_manager": "Мод җыелмасын ясаучыларга кулланучыга иң мөмкин дус рәвешендә бирергә рөхсәт бирә торган Minecraft моды.",
+  "config_manager.title": "Мод җыелмасы көйләүләрен идарә итү",
+  "config_manager.close": "Ябу",
+  "config_manager.confirmation": "Чыннан да телисезме?",
+  "config_manager.success": "Уеныгызны яңадан башлагыз",
+  "config_manager.error": "Хата булды",
+  "config_manager.update_config": "Мод җыелмасы көйләүләрен яңарту",
+  "config_manager.reset_config": "Мод җыелмасы көйләүләрен ташлату",
+  "config_manager.warning.game_restart": "Сезгә уеныгызны яңадан башларга кирәк булачак",
+  "config_manager.warning.lose_some_config": "§eКайбер көйләүләрегез мод җыелмасының гадәти көйләүләренә тулысынча үзгәртелә.§l Хәзерге көйләүләрегез өлешчә күчерелә ала§r\n",
+  "config_manager.warning.lose_all_config": "§c§lБарлык көйләүләрегез бетереләчәк һәм мод җыелмасының гадәти көйләүләренә тулысынча үзгәртелә§r\n"
+}

--- a/common/src/main/resources/assets/config_manager/lang/uk_ua.json
+++ b/common/src/main/resources/assets/config_manager/lang/uk_ua.json
@@ -1,0 +1,12 @@
+{
+  "config_manager.title": "Керування налаштуваннями збірок",
+  "config_manager.close": "Закрити",
+  "config_manager.confirmation": "Ви впевнені?",
+  "config_manager.success": "Перезапустіть гру",
+  "config_manager.error": "Сталася помилка",
+  "config_manager.update_config": "Оновити налаштування збірки",
+  "config_manager.reset_config": "Скинути налаштування збірки",
+  "config_manager.warning.game_restart": "Вам потрібно буде перезапустити гру",
+  "config_manager.warning.lose_some_config": "§eДеякі ваші налаштування будуть замінені усталеними налаштуваннями збірки.§l Ваші поточні налаштування можуть бути частково перезаписані§r\n",
+  "config_manager.warning.lose_all_config": "§c§lУсі ваші поточні налаштування будуть видалені та повністю замінені усталеними налаштуваннями збірки§r\n"
+}


### PR DESCRIPTION
Updated folder name from 'modpack_default' to 'modpack_defaults' in setup instructions.